### PR TITLE
Update script requirements and improve cluster generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ There are **5 stages** outlined below for completing this project, make sure you
    your Proxmox VMs (requires packages from `scripts/requirements.txt`):
 
     ```sh
-    python scripts/generate-cluster.py
+    python scripts/generate-cluster.py --cidr <node CIDR> --cf-domain <domain>
     ```
 
 4. Fill out `cluster.yaml` and `nodes.yaml` configuration files using the comments in those file as a guide.

--- a/scripts/generate-cluster.py
+++ b/scripts/generate-cluster.py
@@ -19,9 +19,13 @@ available fields. The resulting YAML files are meant to be tweaked manually
 before use.
 """
 
+import argparse
 import ipaddress
 import os
+import re
 from typing import Dict, List, Optional
+
+from git import Repo
 
 import yaml
 from proxmoxer import ProxmoxAPI
@@ -31,6 +35,21 @@ ROLE_TAGS = {
     "k3s-worker": "worker",
     "k3s-storage": "storage",
 }
+
+
+def get_repo_name() -> Optional[str]:
+    """Return the GitHub repository name in the form 'owner/repo'."""
+    try:
+        repo = Repo(search_parent_directories=True)
+        remote = repo.remotes.origin
+        url = next(remote.urls)
+    except Exception:  # pragma: no cover - git may not be set up
+        return None
+
+    match = re.search(r"github\.com[:/](.+?)(?:\.git)?$", url)
+    if match:
+        return match.group(1)
+    return None
 
 
 def connect_proxmox() -> Optional[ProxmoxAPI]:
@@ -103,55 +122,70 @@ def compute_cidr(ip: str, prefix: int) -> str:
     return str(network)
 
 
-def generate():
+def generate(network_cidr: Optional[str] = None, cloudflare_domain: Optional[str] = None):
     proxmox = connect_proxmox()
-    if not proxmox:
-        return
-
-    vms = get_vms(proxmox)
-    if not vms:
-        print("No matching VMs found")
-        return
 
     nodes: List[Dict] = []
     cidr: Optional[str] = None
 
-    for vm in vms:
-        node_name = vm["node"]
-        vmid = vm["vmid"]
-        name = vm["name"]
-        tags = {t.strip() for t in (vm.get("tags") or "").split(",") if t.strip()}
+    if proxmox:
+        vms = get_vms(proxmox)
+        if not vms:
+            print("No matching VMs found")
+        else:
+            for vm in vms:
+                node_name = vm["node"]
+                vmid = vm["vmid"]
+                name = vm["name"]
+                tags = {t.strip() for t in (vm.get("tags") or "").split(",") if t.strip()}
 
-        ip, mac, prefix = vm_network_info(proxmox, node_name, vmid)
-        disk = vm_disk_info(proxmox, node_name, vmid)
+                ip, mac, prefix = vm_network_info(proxmox, node_name, vmid)
+                disk = vm_disk_info(proxmox, node_name, vmid)
 
-        if ip and prefix and not cidr:
-            cidr = compute_cidr(ip, prefix)
+                if ip and prefix and not cidr:
+                    cidr = compute_cidr(ip, prefix)
 
-        node_data = {
-            "name": name,
-            "address": ip or "",
-            "controller": "k3s-server" in tags,
-            "disk": disk or "",
-            "mac_addr": mac or "",
-            "schematic_id": "",
-        }
-        nodes.append(node_data)
+                node_data = {
+                    "name": name,
+                    "address": ip or "",
+                    "controller": "k3s-server" in tags,
+                    "disk": disk or "",
+                    "mac_addr": mac or "",
+                    "schematic_id": "",
+                }
+                nodes.append(node_data)
 
-    with open("nodes.yaml", "w") as f:
-        yaml.safe_dump({"nodes": nodes}, f, sort_keys=False)
-        print("nodes.yaml written")
+    if nodes:
+        with open("nodes.yaml", "w") as f:
+            yaml.safe_dump({"nodes": nodes}, f, sort_keys=False)
+            print("nodes.yaml written")
 
     cluster_config = {}
     if os.path.exists("cluster.sample.yaml"):
         with open("cluster.sample.yaml") as f:
             cluster_config = yaml.safe_load(f)
-    if cidr:
+
+    if network_cidr:
+        cluster_config["node_cidr"] = network_cidr
+    elif cidr:
         cluster_config["node_cidr"] = cidr
+
+    repo_name = get_repo_name()
+    if repo_name:
+        cluster_config["repository_name"] = repo_name
+
+    if cloudflare_domain:
+        cluster_config["cloudflare_domain"] = cloudflare_domain
+
     with open("cluster.yaml", "w") as f:
         yaml.safe_dump(cluster_config, f, sort_keys=False)
         print("cluster.yaml written")
 
 
 if __name__ == "__main__":
-    generate()
+    parser = argparse.ArgumentParser(description="Generate cluster.yaml and nodes.yaml")
+    parser.add_argument("--cidr", dest="network_cidr", help="Node network CIDR")
+    parser.add_argument("--cf-domain", dest="cloudflare_domain", help="Cloudflare domain")
+    args = parser.parse_args()
+
+    generate(network_cidr=args.network_cidr, cloudflare_domain=args.cloudflare_domain)

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,11 @@
-PyYAML
-proxmoxer
+certifi==2025.4.26
+charset-normalizer==3.4.2
+gitdb==4.0.12
+GitPython==3.1.41
+idna==3.10
+proxmoxer==2.2.0
+PyYAML==6.0.2
+requests==2.32.4
+setuptools==75.6.0
+smmap==5.0.2
+urllib3==2.4.0


### PR DESCRIPTION
## Summary
- pin Python package versions for scripts
- make `generate-cluster.py` configurable via command line
- auto-populate repository name from git remotes
- document new usage example for the generator

## Testing
- `python3 -m py_compile scripts/generate-cluster.py`
- `python3 scripts/generate-cluster.py --help | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_684b25952d1c8324a7f41c9ffee0b022