### PR TITLE
Fix network info retrieval

### DIFF
--- a/scripts/generate-cluster.py
+++ b/scripts/generate-cluster.py
@@ -122,10 +122,20 @@ def vm_network_info(
     except Exception:  # pragma: no cover - guest agent may not be running
         return None, None, None
     for iface in result.get("result", []):
+        name = iface.get("name")
+        # Skip loopback interface which usually reports 127.0.0.1
+        if name == "lo":
+            continue
         ipv4 = first_ipv4(iface)
         if ipv4:
+            ip = ipv4.get("ip-address")
+            try:
+                if ipaddress.ip_address(ip).is_loopback:
+                    continue
+            except Exception:
+                pass
             return (
-                ipv4.get("ip-address"),
+                ip,
                 iface.get("hardware-address"),
                 ipv4.get("prefix"),
             )


### PR DESCRIPTION
## Summary
- skip loopback interface when querying VM network data in `generate-cluster.py`

## Testing
- `python -m py_compile scripts/generate-cluster.py`
- `python scripts/generate-cluster.py --help`

------
https://chatgpt.com/codex/tasks/task_e_684b347b9dfc8324a856c2b5494bf521