### PR TITLE
Improve env loading and add schematic id option

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,55 @@
+# Environment variables for scripts/generate-cluster.py
+# Values in this file override settings in cluster.sample.yaml when the script
+# is executed. Adjust them to match your environment.
+
+# --- Proxmox API access -----------------------------------------------------
+# Host is required when automatically discovering nodes. Authenticate with
+# either PROXMOX_USER/PROXMOX_PASSWORD or PROXMOX_TOKEN_ID/PROXMOX_TOKEN_SECRET.
+PROXMOX_HOST=
+PROXMOX_USER=
+PROXMOX_PASSWORD=
+PROXMOX_TOKEN_ID=
+PROXMOX_TOKEN_SECRET=
+# Set to 'false' to skip TLS verification
+PROXMOX_VERIFY_SSL=true
+
+# --- Node network configuration --------------------------------------------
+NODE_CIDR=192.168.1.0/24
+# Comma separated list of DNS servers
+NODE_DNS_SERVERS=1.1.1.1,1.0.0.1
+# Comma separated list of NTP servers
+NODE_NTP_SERVERS=162.159.200.1,162.159.200.123
+# Default gateway for the nodes
+NODE_DEFAULT_GATEWAY=192.168.1.1
+# VLAN tag for the nodes if ports are not already tagged
+NODE_VLAN_TAG=
+# Default Talos schematic ID for all nodes
+SCHEMATIC_ID=
+
+# --- Cluster IP configuration ----------------------------------------------
+# Address for the Kubernetes API load balancer
+CLUSTER_API_ADDR=192.168.1.2
+# Optional additional SANs for the API server certificate
+CLUSTER_API_TLS_SANS=
+# Pod and service CIDR ranges
+CLUSTER_POD_CIDR=10.42.0.0/16
+CLUSTER_SVC_CIDR=10.43.0.0/16
+# Internal load balancer addresses
+CLUSTER_DNS_GATEWAY_ADDR=192.168.1.3
+CLUSTER_GATEWAY_ADDR=192.168.1.4
+
+# --- Git repository details -------------------------------------------------
+REPOSITORY_NAME=onedr0p/cluster-template
+REPOSITORY_BRANCH=main
+REPOSITORY_VISIBILITY=public
+
+# --- Cloudflare configuration ----------------------------------------------
+CLOUDFLARE_DOMAIN=example.com
+CLOUDFLARE_TOKEN=
+CLOUDFLARE_GATEWAY_ADDR=192.168.1.5
+
+# --- Advanced Cilium networking --------------------------------------------
+CILIUM_LOADBALANCER_MODE=dsr
+CILIUM_BGP_ROUTER_ADDR=
+CILIUM_BGP_ROUTER_ASN=
+CILIUM_BGP_NODE_ASN=

--- a/scripts/generate-cluster.py
+++ b/scripts/generate-cluster.py
@@ -160,7 +160,7 @@ def compute_cidr(ip: str, prefix: int) -> str:
 
 
 def generate(
-    env_file: Optional[str] = None,
+    schematic_id: Optional[str] = None,
     node_cidr: Optional[str] = None,
     node_dns_servers: Optional[str] = None,
     node_ntp_servers: Optional[str] = None,
@@ -183,10 +183,7 @@ def generate(
     cilium_bgp_router_asn: Optional[str] = None,
     cilium_bgp_node_asn: Optional[str] = None,
 ):
-    if env_file:
-        load_dotenv(env_file)
-    else:
-        load_dotenv()
+    load_dotenv()
 
     proxmox = connect_proxmox()
 
@@ -223,7 +220,7 @@ def generate(
                     "controller": "k3s-server" in tags,
                     "disk": disk or "",
                     "mac_addr": mac or "",
-                    "schematic_id": "",
+                    "schematic_id": schematic_id or os.environ.get("SCHEMATIC_ID", ""),
                 }
                 nodes.append(node_data)
 
@@ -390,11 +387,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Generate cluster.yaml and nodes.yaml"
     )
-    parser.add_argument(
-        "--env-file",
-        default=".env",
-        help="Optional dotenv file",
-    )
+    parser.add_argument("--schematic-id")
     parser.add_argument("--node-cidr")
     parser.add_argument("--node-dns-servers")
     parser.add_argument("--node-ntp-servers")
@@ -423,7 +416,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     generate(
-        env_file=args.env_file,
+        schematic_id=args.schematic_id,
         node_cidr=args.node_cidr,
         node_dns_servers=args.node_dns_servers,
         node_ntp_servers=args.node_ntp_servers,


### PR DESCRIPTION
## Summary
- load `.env` automatically without needing `--env-file`
- allow providing Talos schematic ID via CLI/env
- document `SCHEMATIC_ID` in `.env.sample`

## Testing
- `python3 -m py_compile scripts/generate-cluster.py`
- `python3 scripts/generate-cluster.py --help | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_684b357edaec8324927a551f363f030b