### PR TITLE
feat(coder): manage database with ext-postgres operator

### DIFF
--- a/kubernetes/apps/development/coder/app/externalsecret.yaml
+++ b/kubernetes/apps/development/coder/app/externalsecret.yaml
@@ -16,13 +16,6 @@ spec:
     template:
       engineVersion: v2
       data:
-        # Database Init
-        INIT_POSTGRES_HOST: "${DB_SERVER}"
-        INIT_POSTGRES_DBNAME: "{{.CR_POSTGRES_DB}}"
-        INIT_POSTGRES_USER: "{{.CR_POSTGRES_USER}}"
-        INIT_POSTGRES_PASS: "{{ .CR_POSTGRES_PASSWORD }}"
-        INIT_POSTGRES_SUPER_USER: "{{ .DB_POSTGRES_SUPER_USER }}"
-        INIT_POSTGRES_SUPER_PASS: "{{ .DB_POSTGRES_SUPER_PASS }}"
         # App Configuration
         CODER_EMAIL_AUTH_PASSWORD: "{{ .SMTP_PASSWORD }}"
         CODER_EMAIL_AUTH_USERNAME: "{{ .SMTP_USERNAME }}"
@@ -35,14 +28,10 @@ spec:
         CODER_OIDC_ICON_URL: "{{ .CR_OIDC_ICON_URL }}"
         CODER_OIDC_ISSUER_URL: "{{ .CR_OIDC_ISSUER_URL }}"
         CODER_OIDC_SIGN_IN_TEXT: "{{ .CR_OIDC_SIGN_IN_TEXT }}"
-        CODER_PG_CONNECTION_URL: "postgres://{{ .CR_POSTGRES_USER }}:{{ .CR_POSTGRES_PASSWORD }}@${DB_SERVER}:5432/{{ .CR_POSTGRES_DB }}?sslmode=disable"
   dataFrom:
     - extract:
         key: coder
       rewrite: [{regexp: {source: (.*), target: CR_$1}}]
-    - extract:
-        key: cloudnative-pg
-      rewrite: [{regexp: {source: (.*), target: DB_$1}}]
     - extract:
         key: smtp
       rewrite: [{regexp: {source: (.*), target: SMTP_$1}}]

--- a/kubernetes/apps/development/coder/app/helmrelease.yaml
+++ b/kubernetes/apps/development/coder/app/helmrelease.yaml
@@ -31,6 +31,12 @@ spec:
     coder:
       strategy: Recreate
       env:
+        # --- DATABASE SETTINGS ---
+        - name: CODER_PG_CONNECTION_URL
+          valueFrom:
+            secretKeyRef:
+              name: secret-coder-db-user
+              key: CODER_PG_CONNECTION_URL
         # --- GENERAL SETTINGS ---
         - name: CODER_ACCESS_URL
           value: "https://${GATUS_DOMAIN:=${GATUS_SUBDOMAIN:=${APP}}.${DOMAIN_APP}}"
@@ -89,12 +95,6 @@ spec:
             name: coder-secret
       ingress:
         enable: false
-      initContainers:
-        - name: init-db
-          image: ghcr.io/home-operations/postgres-init:17.5.0@sha256:e0c87ce7df39d06b93f27cf2cc6a056611f13faaa88cc07ab4dc8bf7a85d0b11
-          envFrom:
-            - secretRef:
-                name: coder-secret
       podAnnotations:
         reloader.stakater.com/auto: "true"
         prometheus.io/scrape: "true"

--- a/kubernetes/apps/development/coder/app/kustomization.yaml
+++ b/kubernetes/apps/development/coder/app/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml
+  - ./resources/postgres.yaml
+  - ./resources/postgresuser.yaml
   - ./rbac.yaml
   - ./servicemonitor.yaml
   - ./rules

--- a/kubernetes/apps/development/coder/app/resources/postgres.yaml
+++ b/kubernetes/apps/development/coder/app/resources/postgres.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://schemas.clustrs.dev/db.movetokube.com/postgres_v1alpha1.json
+apiVersion: db.movetokube.com/v1alpha1
+kind: Postgres
+metadata:
+  name: coder
+  namespace: development
+spec:
+  database: coder
+  dropOnDelete: false
+  schemas: []
+  extensions: []

--- a/kubernetes/apps/development/coder/app/resources/postgresuser.yaml
+++ b/kubernetes/apps/development/coder/app/resources/postgresuser.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://schemas.clustrs.dev/db.movetokube.com/postgresuser_v1alpha1.json
+apiVersion: db.movetokube.com/v1alpha1
+kind: PostgresUser
+metadata:
+  name: coder-db-user
+  namespace: development
+spec:
+  role: coder-user
+  database: coder
+  secretName: secret
+  privileges: OWNER
+  annotations:
+    app.kubernetes.io/name: coder
+    app.kubernetes.io/component: database
+  labels:
+    app.kubernetes.io/name: coder
+    app.kubernetes.io/component: database
+  secretTemplate:
+    CODER_PG_CONNECTION_URL: "postgres://{{.Role}}:{{.Password}}@{{.Host}}:{{.Port}}/{{.Database}}?sslmode=disable"
+    PQ_URL: "host={{.Host}} user={{.Role}} password={{.Password}} dbname={{.Database}}"
+    POSTGRES_HOST: "{{.Host}}"
+    POSTGRES_PORT: "{{.Port}}"
+    POSTGRES_DB: "{{.Database}}"
+    POSTGRES_USER: "{{.Role}}"
+    POSTGRES_PASSWORD: "{{.Password}}"

--- a/kubernetes/apps/development/coder/ks.yaml
+++ b/kubernetes/apps/development/coder/ks.yaml
@@ -30,3 +30,7 @@ spec:
   dependsOn:
     - name: onepassword-store
       namespace: external-secrets
+    - name: cloudnative-pg-cluster
+      namespace: database
+    - name: ext-postgres-operator
+      namespace: database


### PR DESCRIPTION
## Summary
- add Postgres and PostgresUser resources for the coder deployment
- reference the operator-managed secret for the application database connection and drop the manual init container
- ensure the coder kustomization waits for the database operator dependencies

## Testing
- [ ] Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d448872cd883248b46962ef3b53023